### PR TITLE
fix preact support

### DIFF
--- a/packages/ariakit-core/src/utils/events.ts
+++ b/packages/ariakit-core/src/utils/events.ts
@@ -89,8 +89,8 @@ export function fireEvent(
 export function fireBlurEvent(element: Element, eventInit?: FocusEventInit) {
   const event = new FocusEvent("blur", eventInit);
   const defaultAllowed = element.dispatchEvent(event);
-  const bubbleInit = { ...eventInit, bubbles: true };
-  element.dispatchEvent(new FocusEvent("focusout", bubbleInit));
+  Object.defineProperty(eventInit, "bubbles", { writable: false, value: true });
+  element.dispatchEvent(new FocusEvent("focusout", eventInit));
   return defaultAllowed;
 }
 
@@ -102,8 +102,8 @@ export function fireBlurEvent(element: Element, eventInit?: FocusEventInit) {
 export function fireFocusEvent(element: Element, eventInit?: FocusEventInit) {
   const event = new FocusEvent("focus", eventInit);
   const defaultAllowed = element.dispatchEvent(event);
-  const bubbleInit = { ...eventInit, bubbles: true };
-  element.dispatchEvent(new FocusEvent("focusin", bubbleInit));
+  Object.defineProperty(eventInit, "bubbles", { writable: false, value: true });
+  element.dispatchEvent(new FocusEvent("focusin", eventInit));
   return defaultAllowed;
 }
 

--- a/packages/ariakit-react-core/src/command/command.tsx
+++ b/packages/ariakit-react-core/src/command/command.tsx
@@ -96,10 +96,13 @@ export const useCommand = createHook<TagName, CommandOptions>(
         if (isEnter) {
           if (!nativeClick) {
             event.preventDefault();
-            const { view, ...eventInit } = event;
             // Fire a click event instead of calling element.click() directly so
             // we can pass along the modifier state.
-            const click = () => fireClickEvent(element, eventInit);
+            const click = () =>
+              fireClickEvent(
+                element,
+                event as Omit<React.KeyboardEvent, "view">,
+              );
             // If this element is a link with target="_blank", Firefox will
             // block the "popup" if the click event is dispatched synchronously
             // or in a microtask. Queueing the event asynchronously fixes that.
@@ -137,8 +140,9 @@ export const useCommand = createHook<TagName, CommandOptions>(
           event.preventDefault();
           setActive(false);
           const element = event.currentTarget;
-          const { view, ...eventInit } = event;
-          queueMicrotask(() => fireClickEvent(element, eventInit));
+          queueMicrotask(() =>
+            fireClickEvent(element, event as Omit<React.KeyboardEvent, "view">),
+          );
         }
       }
     });

--- a/packages/ariakit-react-core/src/composite/composite.tsx
+++ b/packages/ariakit-react-core/src/composite/composite.tsx
@@ -79,7 +79,6 @@ function useKeyboardEventProxy(
     const state = store.getState();
     const activeElement = getEnabledItem(store, state.activeId)?.element;
     if (!activeElement) return;
-    const { view, ...eventInit } = event;
     const previousElement = previousElementRef?.current;
     // If the active item element is not the previous element, this means that
     // it hasn't been focused (for example, when using composite hover). So we
@@ -87,7 +86,13 @@ function useKeyboardEventProxy(
     if (activeElement !== previousElement) {
       activeElement.focus();
     }
-    if (!fireKeyboardEvent(activeElement, event.type, eventInit)) {
+    if (
+      !fireKeyboardEvent(
+        activeElement,
+        event.type,
+        event as Omit<React.KeyboardEvent, "view">,
+      )
+    ) {
       event.preventDefault();
     }
     // The event will be triggered on the composite item and then propagated up

--- a/packages/ariakit-react-core/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-core/src/focusable/focusable.tsx
@@ -336,7 +336,10 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       currentTarget?: HTMLType,
     ) => {
       if (currentTarget) {
-        event.currentTarget = currentTarget;
+        Object.defineProperty(event, "currentTarget", {
+          writable: false,
+          value: currentTarget,
+        });
       }
       if (!focusable) return;
       const element = event.currentTarget;

--- a/packages/ariakit-react-core/src/utils/hooks.ts
+++ b/packages/ariakit-react-core/src/utils/hooks.ts
@@ -29,7 +29,6 @@ import type { WrapElement } from "./types.ts";
 const _React = { ...React };
 const useReactId = _React.useId;
 const useReactDeferredValue = _React.useDeferredValue;
-const useReactInsertionEffect = _React.useInsertionEffect;
 
 /**
  * `React.useLayoutEffect` that fallbacks to `React.useEffect` on server side.
@@ -102,15 +101,10 @@ export function usePreviousValue<T>(value: T) {
  */
 export function useEvent<T extends AnyFunction>(callback?: T) {
   const ref = useRef<AnyFunction | undefined>(() => {
-    throw new Error("Cannot call an event handler while rendering.");
+    console.error("Cannot call an event handler while rendering.");
   });
-  if (useReactInsertionEffect) {
-    useReactInsertionEffect(() => {
-      ref.current = callback;
-    });
-  } else {
-    ref.current = callback;
-  }
+  // TODO: Wrap this in useEffect
+  ref.current = callback;
   return useCallback<AnyFunction>((...args) => ref.current?.(...args), []) as T;
 }
 


### PR DESCRIPTION
This is an attempt at fixing the most obvious issues with Preact usage.
1. Removed the `throw` and `useInsertionEffect` in `useEvent`. There is a timing issue here which I haven't figured out.
2. Using `Object.defineProperty` instead of directly mutating `event.currentTarget` (it does not have a setter).
3. Removed all instances of `...eventInit` which turn out to be empty (because DOM event properties are not enumerable). Replaced with type assertion and `Object.defineProperty`.

There might be other issues discovered in the future.

Related: https://github.com/ariakit/ariakit/discussions/2690

---

**Follow-up PRs:**
- https://github.com/mayank99/ariakit-fork/pull/2